### PR TITLE
Possible fix for safari mobile scale/sizing

### DIFF
--- a/announcement/index.php
+++ b/announcement/index.php
@@ -2,11 +2,12 @@
 "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
+<?php include('../include/head-start.php'); ?>
 <title>Church of the Epiphany: Special announcement</title>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js" ></script>
 <?php include("../include/google_analytics.inc"); ?>
 <script>
-// Once the page has fully loaded (i.e., we sent out Google Analytics 
+// Once the page has fully loaded (i.e., we sent out Google Analytics
 // pageview then redirect to the announcement page.  Yay jquery!
 $(document).ready(function(){
     window.location.replace("http://www.churchofepiphany.com/epiphany/mass-and-prayer");

--- a/calendar/index.php
+++ b/calendar/index.php
@@ -2,6 +2,7 @@
 "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
+<?php include('../include/head-start.php'); ?>
 <title>COE: Epiphany events</title>
 <style>
 .responsive-iframe-container {
@@ -11,8 +12,8 @@
     height: 0;
     overflow: auto;
 }
-.responsive-iframe-container iframe,  
-.vresponsive-iframe-container object, 
+.responsive-iframe-container iframe,
+.vresponsive-iframe-container object,
 .vresponsive-iframe-container embed {
     position: absolute;
     top: 0;

--- a/include/head-start.php
+++ b/include/head-start.php
@@ -1,0 +1,3 @@
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@
 "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
+<?php include('include/head-start.php'); ?>
 <title>Church of the Epiphany</title>
 <link type="text/css" rel="stylesheet" href="http://m.churchofepiphany.com/css/master.css" />
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js" ></script>

--- a/liturgies/index.php
+++ b/liturgies/index.php
@@ -2,9 +2,10 @@
 "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
+<?php include('../include/head-start.php'); ?>
 <title>Church of the Epiphany</title>
 <link type="text/css" rel="stylesheet" href="http://m.churchofepiphany.com/css/master.css" />
-<?php 
+<?php
 print("<style>");
 include("../css/statue-background.css");
 print("</style>\n");


### PR DESCRIPTION
These meta elements should help communicate the intent of the webpage
  standard for most responsive websites.

NOTE: I suggest you switch to HTML5 vs. the current XHTML doctype